### PR TITLE
Run natively on macOS and Linux (keep WSL on Windows)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![PowerShell](https://img.shields.io/badge/PowerShell-7%2B-blue.svg)](https://docs.microsoft.com/en-us/powershell/)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
-[![Platform](https://img.shields.io/badge/Platform-Windows%2BWSL-lightgrey.svg)](https://docs.microsoft.com/en-us/windows/wsl/)
+[![Platform](https://img.shields.io/badge/Platform-Windows%20%7C%20macOS%20%7C%20Linux-lightgrey.svg)](#prerequisites)
 [![Veeam](https://img.shields.io/badge/Veeam-v13.0-00B336.svg)](https://www.veeam.com/)
 
 > 🚀 **Enterprise-grade PowerShell automation tool for customizing Veeam Software Appliance ISO files.**
@@ -94,29 +94,35 @@ https://www.veeam.com/kb4772
 ## Prerequisites
 
 ### System Requirements
-- **Operating System**: Windows 10/11 or Windows Server 2016+
+- **Operating System**: one of
+    - Windows 10/11 or Windows Server 2016+, with WSL (Ubuntu/Debian recommended)
+    - macOS
+    - Linux (Ubuntu/Debian, or RHEL/Rocky/Alma)
 - **PowerShell**: Version 7 or higher
-- **WSL**: Windows Subsystem for Linux (Ubuntu/Debian recommended)
 - **Memory**: Minimum 4GB RAM (8GB recommended for large ISOs)
 - **Storage**: At least 14GB free space for ISO manipulation
 
 ### Software Dependencies
-**Software dependencies:**
-- `xorriso` installed in WSL
-    ```
-    sudo apt-get update
-    sudo apt-get install xorriso
-    ```
-- For RHEL/CentOS/Rocky:
-    ```
-    sudo yum install xorriso
-    ```
+
+`xorriso` is the only external dependency. On Windows it runs inside WSL; on macOS and Linux
+the script calls it directly.
+
+| Platform | Install command |
+|---|---|
+| Windows (in WSL) | `wsl sudo apt-get update && wsl sudo apt-get install -y xorriso` |
+| macOS | `brew update && brew install xorriso` |
+| Ubuntu/Debian | `sudo apt-get update && sudo apt-get install -y xorriso` |
+| RHEL/Rocky/Alma | `sudo dnf install -y xorriso` |
 
 **PowerShell configuration:**
 - Run with an appropriate execution policy
-- Confirm WSL is accessible:
+- Confirm your setup:
     ```
+    # Windows: check WSL is accessible
     wsl --version
+
+    # macOS / Linux: check xorriso is on your PATH
+    xorriso -version
     ```
 
 ### Optionnal Dependencies
@@ -367,17 +373,27 @@ Process completed successfully
 ## Troubleshooting
 
 ### Making ISO
+
+**On Windows (WSL):**
 - If you just installed WSL, you need to reboot
 - Ensure WSL is installed and available (`wsl --list --verbose`)
 - Install `xorriso` in WSL (`sudo apt-get install xorriso`) or update it
 - If you just installed WSL, you might have permission issue, reboot Windows
+
+**On macOS / Linux:**
+- Ensure `xorriso` is on your PATH (`xorriso -version`). If it is missing, the script prints the
+  install command for your platform and exits.
+
+**All platforms:**
 - Confirm ISO file is located in the same directory as the script
 - Use correct JSON structure with all parameters
 - All parameters MUST be defined in the JSON file. Since v2.7 the only CLI argument the script accepts is `-ConfigFile`; any other CLI argument is rejected by PowerShell as unknown.
 - If you use optionnal features: check prerequisite and folder structure
 - Use `$CFGOnly=true` to verify your kickstart file contain all Configurations Blocks
 - Check log file `ISO_Customization.log` for timestamped error messages
-- to browse ISO with WSL xorriso `wsl xorriso -indev "VeeamSoftwareAppliance_13.0.0.4967_20250822.iso" -ls /`
+- to browse the ISO contents:
+    - Windows: `wsl xorriso -indev "VeeamSoftwareAppliance_13.0.0.4967_20250822.iso" -ls /`
+    - macOS/Linux: `xorriso -indev "VeeamSoftwareAppliance_13.0.0.4967_20250822.iso" -ls /`
 
 ### Booting ISO
 - If your specified answers do not meet these requirements, the configuration process will fail. To troubleshoot errors, you can use the Live OS ISO to view the `/var/log/VeeamBackup/veeam_hostmanager/veeamhostmanager.log` file and the system logs files in the `/var/log/anaconda directory.`
@@ -396,7 +412,8 @@ Process completed successfully
 #### ISO File Access
 - **File Locks**: Ensure ISO files aren't mounted or locked by other applications
 - **Permissions**: Verify read/write access to ISO file location
-- **Path Format**: don't use path, put ISO in the same directory to avoid issue with WSL
+- **Path Format**: don't use paths, put the ISO in the same directory as the script. On Windows
+  this avoids WSL path-translation issues; on all platforms it keeps filenames portable.
 
 ---
 

--- a/autodeploy.ps1
+++ b/autodeploy.ps1
@@ -512,19 +512,36 @@ function Resolve-XorrisoInvoker {
     Write-Log "xorriso invoker: $script:XorrisoCommand $($script:XorrisoArgPrefix -join ' ')" 'Info'
 }
 
-function Invoke-WSLCommand {
+function Invoke-Xorriso {
+    <#
+    .SYNOPSIS
+        Runs an xorriso command on any supported platform.
+    .DESCRIPTION
+        Takes arguments as an array and invokes the binary directly, so no
+        shell parses the command line. This is what allows paths containing
+        spaces to survive, and it removes the previous dependency on cmd.exe.
+
+        Requires Resolve-XorrisoInvoker to have run first.
+    #>
     param(
         [Parameter(Mandatory = $true)]
-        [string]$Command,
+        [string[]]$Arguments,
         [Parameter(Mandatory = $false)]
-        [string]$Description = "WSL Command"
+        [string]$Description = "xorriso command"
     )
 
-    try {
-        Write-Log "Executing: $Description" 'Info'
-        Write-Log "Command: $Command" 'Info'
+    if ([string]::IsNullOrWhiteSpace($script:XorrisoCommand)) {
+        Write-Log "Invoke-Xorriso called before Resolve-XorrisoInvoker" 'Error'
+        return $false
+    }
 
-        $output = & cmd /c $Command 2>&1
+    try {
+        $allArgs = @($script:XorrisoArgPrefix) + $Arguments
+
+        Write-Log "Executing: $Description" 'Info'
+        Write-Log "Command: $script:XorrisoCommand $($allArgs -join ' ')" 'Info'
+
+        $output = & $script:XorrisoCommand @allArgs 2>&1
         $exitCode = $LASTEXITCODE
 
         if ($exitCode -ne 0) {

--- a/autodeploy.ps1
+++ b/autodeploy.ps1
@@ -483,6 +483,35 @@ function Initialize-ISOOperation {
     }
 }
 
+function Resolve-XorrisoInvoker {
+    <#
+    .SYNOPSIS
+        Determines how to launch xorriso on the current platform.
+    .DESCRIPTION
+        Windows has no native xorriso, so it is invoked through WSL. macOS and
+        Linux call the binary directly. Called once at startup; every xorriso
+        call then goes through Invoke-Xorriso without knowing the platform.
+
+        WindowsPlatform is a parameter rather than a direct $IsWindows read so
+        both branches can be tested - $IsWindows is read-only and cannot be
+        mocked.
+    #>
+    param(
+        [bool]$WindowsPlatform = $IsWindows
+    )
+
+    if ($WindowsPlatform) {
+        $script:XorrisoCommand   = 'wsl'
+        $script:XorrisoArgPrefix = @('xorriso')
+    }
+    else {
+        $script:XorrisoCommand   = 'xorriso'
+        $script:XorrisoArgPrefix = @()
+    }
+
+    Write-Log "xorriso invoker: $script:XorrisoCommand $($script:XorrisoArgPrefix -join ' ')" 'Info'
+}
+
 function Invoke-WSLCommand {
     param(
         [Parameter(Mandatory = $true)]

--- a/autodeploy.ps1
+++ b/autodeploy.ps1
@@ -766,8 +766,8 @@ function Invoke-ISOExtractConfig {
     )
 
     $extractCommands = @(
-        @('-boot_image', 'any', 'keep', '-dev', $TargetISO, '-osirrox', 'on', '-extract', $KickstartName, $KickstartName),
-        @('-boot_image', 'any', 'keep', '-dev', $TargetISO, '-osirrox', 'on', '-extract', '/EFI/BOOT/grub.cfg', 'grub.cfg')
+        @('-dev', $TargetISO, '-boot_image', 'any', 'replay', '-osirrox', 'on', '-extract', $KickstartName, $KickstartName),
+        @('-dev', $TargetISO, '-boot_image', 'any', 'replay', '-osirrox', 'on', '-extract', '/EFI/BOOT/grub.cfg', 'grub.cfg')
     )
 
     foreach ($cmdArgs in $extractCommands) {
@@ -792,11 +792,14 @@ function Invoke-ISOCommit {
 
     Write-Log "Committing changes to ISO..." 'Info'
 
+    # -dev must precede -boot_image: 'replay' needs the image already loaded.
+    # 'replay' rather than 'keep' - keep drops the isohybrid MBR flag and the
+    # isolinux boot-info-table, which breaks booting from a dd'd USB stick.
     $commitCommands = @(
-        @('-boot_image', 'any', 'keep', '-dev', $TargetISO, '-rm', $KickstartName),
-        @('-boot_image', 'any', 'keep', '-dev', $TargetISO, '-map', $KickstartName, $KickstartName),
-        @('-boot_image', 'any', 'keep', '-dev', $TargetISO, '-rm', '/EFI/BOOT/grub.cfg'),
-        @('-boot_image', 'any', 'keep', '-dev', $TargetISO, '-map', 'grub.cfg', '/EFI/BOOT/grub.cfg')
+        @('-dev', $TargetISO, '-boot_image', 'any', 'replay', '-rm', $KickstartName),
+        @('-dev', $TargetISO, '-boot_image', 'any', 'replay', '-map', $KickstartName, $KickstartName),
+        @('-dev', $TargetISO, '-boot_image', 'any', 'replay', '-rm', '/EFI/BOOT/grub.cfg'),
+        @('-dev', $TargetISO, '-boot_image', 'any', 'replay', '-map', 'grub.cfg', '/EFI/BOOT/grub.cfg')
     )
 
     foreach ($cmdArgs in $commitCommands) {
@@ -826,7 +829,7 @@ function Add-FolderToISO {
     )
 
     if (-not (Test-Path $LocalPath)) { return }
-    $cmdArgs = @('-boot_image', 'any', 'keep', '-dev', $TargetISO, '-map', $LocalPath, $ISOPath)
+    $cmdArgs = @('-dev', $TargetISO, '-boot_image', 'any', 'replay', '-map', $LocalPath, $ISOPath)
     Invoke-Xorriso -Arguments $cmdArgs -Description "Add $LocalPath folder to ISO" | Out-Null
 }
 

--- a/autodeploy.ps1
+++ b/autodeploy.ps1
@@ -24,7 +24,7 @@ Enhanced Features:
 - APPLIANCE TYPE SELECTION: Support for VSA, VIA, VIAVMware, and VIAHR appliances with dedicated deployment workflows
 - JSON CONFIGURATION SUPPORT: Load all parameters from JSON configuration files for easy deployment management
 - OUT-OF-PLACE ISO MODIFICATION: Creates customized copies without modifying the original ISO
-- PATH HANDLING: Works ONLY in the current directory to avoid WSL path issues
+- PATH HANDLING: Works ONLY in the current directory to keep paths portable across platforms
 - Network Configuration: Supports both DHCP and static IP configurations with comprehensive validation
 - Regional Settings: Configures keyboard layouts and timezone settings with proper validation
 - Veeam Configuration Management: Implements Veeam auto deploy 
@@ -32,7 +32,8 @@ Enhanced Features:
 - Service Provider Integration: Automated VCSP connection and management agent installation - v13.0.1 required
 - Enterprise Logging: Comprehensive logging system with timestamped Info/Warn/Error levels + output log file in current folder
 
-The script utilizes WSL (Windows Subsystem for Linux) with xorriso for ISO manipulation.
+The script uses xorriso for ISO manipulation. On macOS and Linux xorriso is called directly;
+on Windows it is invoked through WSL, which is where xorriso lives on that platform.
 
 official Veeam documentation: https://helpcenter.veeam.com/docs/vbr/userguide/deployment_linux_silent_deploy_configure.html?ver=13
 
@@ -217,13 +218,17 @@ Run the script (JSON-only mode -- this is the only supported invocation):
 .NOTES
 File Name      : autodeploy.ps1
 Author         : Baptiste TELLIER
-Prerequisite   : PowerShell 7+, WSL with xorriso installed
+Prerequisite   : PowerShell 7+ and xorriso (via WSL on Windows; native on macOS/Linux)
 Version        : 2.7
 Creation Date  : 24/09/2025
 Last Modified  : 26/11/2025
 
 REQUIREMENTS:
-- Windows Subsystem for Linux (WSL) with xorriso package installed
+- xorriso:
+    Windows      : WSL with the xorriso package installed
+    macOS        : brew update && brew install xorriso
+    Ubuntu/Debian: sudo apt-get update && sudo apt-get install -y xorriso
+    RHEL/Rocky   : sudo dnf install -y xorriso
 - Source ISO file must be in the same directory as this script
 - Optional: JSON configuration file for simplified parameter management
 - Optional: 'license' folder with .lic files for license automation

--- a/autodeploy.ps1
+++ b/autodeploy.ps1
@@ -705,12 +705,12 @@ function Invoke-ISOExtractConfig {
     )
 
     $extractCommands = @(
-        "wsl xorriso -boot_image any keep -dev `"$TargetISO`" -osirrox on -extract $KickstartName $KickstartName",
-        "wsl xorriso -boot_image any keep -dev `"$TargetISO`" -osirrox on -extract /EFI/BOOT/grub.cfg grub.cfg"
+        @('-boot_image', 'any', 'keep', '-dev', $TargetISO, '-osirrox', 'on', '-extract', $KickstartName, $KickstartName),
+        @('-boot_image', 'any', 'keep', '-dev', $TargetISO, '-osirrox', 'on', '-extract', '/EFI/BOOT/grub.cfg', 'grub.cfg')
     )
 
-    foreach ($cmd in $extractCommands) {
-        if (-not (Invoke-WSLCommand -Command $cmd -Description "Extract configuration files")) {
+    foreach ($cmdArgs in $extractCommands) {
+        if (-not (Invoke-Xorriso -Arguments $cmdArgs -Description "Extract configuration files")) {
             throw "Failed to extract files from ISO"
         }
     }
@@ -732,14 +732,14 @@ function Invoke-ISOCommit {
     Write-Log "Committing changes to ISO..." 'Info'
 
     $commitCommands = @(
-        "wsl xorriso -boot_image any keep -dev `"$TargetISO`" -rm $KickstartName",
-        "wsl xorriso -boot_image any keep -dev `"$TargetISO`" -map $KickstartName $KickstartName",
-        "wsl xorriso -boot_image any keep -dev `"$TargetISO`" -rm /EFI/BOOT/grub.cfg",
-        "wsl xorriso -boot_image any keep -dev `"$TargetISO`" -map grub.cfg /EFI/BOOT/grub.cfg"
+        @('-boot_image', 'any', 'keep', '-dev', $TargetISO, '-rm', $KickstartName),
+        @('-boot_image', 'any', 'keep', '-dev', $TargetISO, '-map', $KickstartName, $KickstartName),
+        @('-boot_image', 'any', 'keep', '-dev', $TargetISO, '-rm', '/EFI/BOOT/grub.cfg'),
+        @('-boot_image', 'any', 'keep', '-dev', $TargetISO, '-map', 'grub.cfg', '/EFI/BOOT/grub.cfg')
     )
 
-    foreach ($cmd in $commitCommands) {
-        if (-not (Invoke-WSLCommand -Command $cmd -Description "Commit changes to ISO")) {
+    foreach ($cmdArgs in $commitCommands) {
+        if (-not (Invoke-Xorriso -Arguments $cmdArgs -Description "Commit changes to ISO")) {
             throw "Failed to commit changes to ISO"
         }
     }
@@ -765,8 +765,8 @@ function Add-FolderToISO {
     )
 
     if (-not (Test-Path $LocalPath)) { return }
-    $cmd = "wsl xorriso -boot_image any keep -dev `"$TargetISO`" -map $LocalPath $ISOPath"
-    Invoke-WSLCommand -Command $cmd -Description "Add $LocalPath folder to ISO" | Out-Null
+    $cmdArgs = @('-boot_image', 'any', 'keep', '-dev', $TargetISO, '-map', $LocalPath, $ISOPath)
+    Invoke-Xorriso -Arguments $cmdArgs -Description "Add $LocalPath folder to ISO" | Out-Null
 }
 
 #endregion

--- a/autodeploy.ps1
+++ b/autodeploy.ps1
@@ -398,32 +398,88 @@ function Update-ParametersFromJSON {
 
 #region Helper Functions
 
+function Get-XorrisoInstallHint {
+    <#
+    .SYNOPSIS
+        Returns a runnable command that installs xorriso on this platform.
+    .DESCRIPTION
+        Reads ID and ID_LIKE from /etc/os-release. ID_LIKE is what maps
+        derivatives onto their parent's package manager - Rocky/Alma/CentOS
+        to dnf, Mint/Pop to apt-get - without enumerating every distro.
+
+        Returns the command as text. The caller prints it; the script never
+        runs a package manager itself.
+    #>
+    param(
+        [string]$OsReleasePath = '/etc/os-release',
+        [bool]$MacOSPlatform = $IsMacOS
+    )
+
+    $generic = "xorriso not found on PATH. Install it with your distribution's package manager."
+
+    if ($MacOSPlatform) {
+        return 'brew update && brew install xorriso'
+    }
+
+    if (-not (Test-Path $OsReleasePath)) {
+        return $generic
+    }
+
+    # Match ID= and ID_LIKE=, tolerating optional surrounding quotes.
+    $osRelease = Get-Content $OsReleasePath -Raw
+    $id     = if ($osRelease -match '(?m)^ID="?([^"\r\n]*)"?')      { $Matches[1] } else { '' }
+    $idLike = if ($osRelease -match '(?m)^ID_LIKE="?([^"\r\n]*)"?') { $Matches[1] } else { '' }
+    $family = "$id $idLike"
+
+    if ($family -match '(?i)\b(debian|ubuntu)\b') {
+        return 'sudo apt-get update && sudo apt-get install -y xorriso'
+    }
+    if ($family -match '(?i)\b(rhel|fedora|centos)\b') {
+        return 'sudo dnf install -y xorriso'
+    }
+
+    return $generic
+}
+
 function Test-Prerequisites {
     Write-Log "Testing prerequisites..." 'Info'
 
-    try {
-        $wslTest = & wsl echo "test" 2>$null
-        if ($wslTest -ne "test") {
-            throw "WSL is not available or not responding correctly"
+    if ($IsWindows) {
+        # Windows has no native xorriso - it runs inside WSL.
+        try {
+            $wslTest = & wsl echo "test" 2>$null
+            if ($wslTest -ne "test") {
+                throw "WSL is not available or not responding correctly"
+            }
+            Write-Log "WSL is available" 'Info'
         }
-        Write-Log "WSL is available" 'Info'
-    }
-    catch {
-        Write-Log "WSL test failed: $($_.Exception.Message)" 'Error'
-        return $false
-    }
+        catch {
+            Write-Log "WSL test failed: $($_.Exception.Message)" 'Error'
+            return $false
+        }
 
-    try {
-        $xorrisoTest = & wsl which xorriso 2>$null
-        if ([string]::IsNullOrWhiteSpace($xorrisoTest)) {
-            throw "xorriso not found. Install with: wsl sudo apt-get install xorriso"
+        try {
+            $xorrisoTest = & wsl which xorriso 2>$null
+            if ([string]::IsNullOrWhiteSpace($xorrisoTest)) {
+                throw "xorriso not found. Install with: wsl sudo apt-get install xorriso"
+            }
+            Write-Log "xorriso is available at: $xorrisoTest" 'Info'
         }
-        Write-Log "xorriso is available at: $xorrisoTest" 'Info'
+        catch {
+            Write-Log "xorriso test failed: $($_.Exception.Message)" 'Error'
+            Write-Log "Please install xorriso: wsl sudo apt-get update && wsl sudo apt-get install xorriso" 'Error'
+            return $false
+        }
     }
-    catch {
-        Write-Log "xorriso test failed: $($_.Exception.Message)" 'Error'
-        Write-Log "Please install xorriso: wsl sudo apt-get update && wsl sudo apt-get install xorriso" 'Error'
-        return $false
+    else {
+        # macOS and Linux call xorriso directly.
+        $xorrisoCmd = Get-Command xorriso -ErrorAction SilentlyContinue
+        if (-not $xorrisoCmd) {
+            Write-Log "xorriso not found on PATH" 'Error'
+            Write-Log "Install it with: $(Get-XorrisoInstallHint)" 'Error'
+            return $false
+        }
+        Write-Log "xorriso is available at: $($xorrisoCmd.Source)" 'Info'
     }
 
     if (-not (Test-Path $SourceISO)) {
@@ -1745,6 +1801,10 @@ try {
     }
 
     Write-Log "Selected Appliance Type: $ApplianceType" 'Info'
+
+    # Decide how xorriso is launched on this platform before any workflow
+    # calls Invoke-Xorriso. Every appliance type passes through here.
+    Resolve-XorrisoInvoker
 
     switch ($ApplianceType) {
         "VSA" {


### PR DESCRIPTION
## Summary

Makes `autodeploy.ps1` run natively on macOS and Linux, while keeping Windows on WSL exactly as it works today.

The script was already PowerShell 7 and almost entirely portable — no `.exe` calls, no `$env:` path assumptions, and it already normalises line endings. The only real blocker was the executor: `Invoke-WSLCommand` built command *strings* and ran them through `& cmd /c`, which only exists on Windows.

This PR contains **two separable changes**. Please feel free to take one and not the other — they're in separate commits.

---

## 1. Cross-platform port

`Resolve-XorrisoInvoker` runs once at startup and records how to launch xorriso, using PowerShell 7's built-in `$IsWindows`:

| Platform | Invocation |
|---|---|
| Windows | `wsl xorriso <args>` — unchanged from today |
| macOS / Linux | `xorriso <args>` — native |

`Invoke-WSLCommand` is replaced by `Invoke-Xorriso`, which takes a `[string[]]` argument array and invokes the binary directly — no `cmd /c`, no `Invoke-Expression`, no intermediate shell. The three call sites (`Invoke-ISOExtractConfig`, `Invoke-ISOCommit`, `Add-FolderToISO`) pass argument arrays instead of strings.

The platform check lives in exactly one function. The call sites never learn what platform they're on, so adding native `xorriso.exe` support on Windows later would mean changing `Resolve-XorrisoInvoker` and nothing else.

**Windows behaviour is unchanged by this part**: same `wsl xorriso`, same relative paths, same current-directory rule. The `Test-Prerequisites` WSL checks are byte-identical — just moved inside an `if ($IsWindows)` branch. On macOS/Linux it resolves `xorriso` on PATH and, if missing, prints the exact install command for the detected platform (`brew` / `apt-get` / `dnf`, chosen from `ID`/`ID_LIKE` in `/etc/os-release`) and exits. It only prints the command — it never runs a package manager itself.

**Side benefit:** because arguments are no longer parsed by a shell, ISO paths containing spaces now work. Previously `cmd /c` split them.

The "keep everything in the current directory" rule is untouched — it works the same natively as it did for WSL.

---

## 2. Boot record fix (separate commit — pre-existing, independent of the port)

While verifying the port I found that **`-boot_image any keep` silently damages the boot record**, on every platform including Windows today:

- the isohybrid MBR flag is dropped
- the isolinux `boot-info-table` is dropped
- the MBR partition table keeps the *original* image size, so it no longer spans the grown image

Result: modified ISOs still boot as virtual media (El Torito survives), but **fail to boot when written to a USB stick with `dd`**.

This is not caused by the port — it reproduces with a single bare `xorriso -boot_image any keep -dev X -rm Y`, no script involved.

`-boot_image any replay` re-applies the recorded boot setup and preserves all of it. `-dev` must come before `-boot_image`, since `replay` needs the image already loaded.

Measured against a real `VeeamSoftwareAppliance_13.0.2.29` ISO:

| | Source | `keep` (before) | `replay` (after) |
|---|---|---|---|
| System area | `MBR isohybrid cyl-align-off GPT` | `MBR cyl-align-off GPT` | `MBR isohybrid cyl-align-off GPT` |
| El Torito img opts | `boot-info-table isohybrid-suitable` | *(none)* | `boot-info-table isohybrid-suitable` |
| MBR part 1 / image size | 27149444 / 27149444 | 27149444 / 27152064 ❌ | 27154124 / 27154124 ✅ |

The BIOS boot image LBA legitimately changes under `replay` (6730 → 6788494): xorriso relocates `isolinux.bin` and re-patches its `boot-info-table` to match, which is exactly what that table is for.

⚠️ **Note:** unlike part 1, this change *does* alter the xorriso arguments on Windows too. It's in its own commit if you'd prefer to take the port alone and handle this separately.

---

## Testing

Both platforms ran the full extract → modify → commit cycle against a real `VeeamSoftwareAppliance_13.0.2.29_20260617.iso` (13.9 GB), VSA workflow, out-of-place, DHCP, licence file. Verified by **re-extracting `grub.cfg` and `vbr-ks.cfg` from the output ISO** and asserting the values landed — not by trusting the script's own success log — plus confirming the source ISO's sha256 was unchanged and the El Torito record survived.

| | macOS 15 | Ubuntu 24.04.4 |
|---|---|---|
| PowerShell | 7.5.4 | 7.6.3 |
| xorriso | 1.5.8 | 1.5.6 |
| Result | ✅ hostname, timezone, grub timeout, LF endings all correct; source untouched; isohybrid preserved | ✅ identical, incl. same MBR block count |

**Not tested — stated plainly rather than implied:**

- **Windows / WSL** — no access to a Windows machine. Part 1 leaves that path unchanged by design; part 2 does change its xorriso arguments and would benefit from a check by someone who can run it.
- **RHEL / dnf** — the `dnf` hint string is reasoned from `ID_LIKE`, not exercised on a RHEL host. It's error-path-only code (it selects the text printed when xorriso is missing).
- **Other appliance types** — only VSA was run end-to-end. VIA/VIAVMware/VIAHR share the same `Invoke-Xorriso` path, so the risk is low, but they weren't exercised.
- **Booting a produced ISO** — the boot *record* is verified structurally against the source; no appliance was actually deployed from the output.
